### PR TITLE
Move money between own accounts (mistake)

### DIFF
--- a/newbank/server/NewBank.java
+++ b/newbank/server/NewBank.java
@@ -46,7 +46,7 @@ public class NewBank {
 	public synchronized String processRequest(CustomerID customer, String request) {
 		String command = request.split( "\\s+" )[0];
 		if (customers.containsKey(customer.getKey())) {
-			switch (request.toLowerCase(Locale.ROOT)) {
+			switch (command) {
 				case "showmyaccounts":
 					return showMyAccounts(customer);
 				case "help":


### PR DESCRIPTION
For Ticket -> [7. Addition/Protocol: MOVE money between own accounts](https://trello.com/c/jlfZWVtG/21-addition-protocol-move-money-between-own-accounts)

This is a total work-in-progress!

This change adds a MOVE function which is similar to the PAY function but reduces the parameter checks to 4 (i.e., `<MOVE> <Account> <Account> <Amount>`).

@saundap - I saw that you mentioned your merge went to main. I've tried to reconcile your additions to mine, but I'm not having much success with getting mine to recognise MOVE anymore (or PAY now for that matter). Please can you have a look?

I've not yet figured out how to separate each account into its own instance and select a specific accountFrom and accountTo. Any pointers would be appreciated! I've commented out my attempt at altering the account class to be a builder class - maybe that's a good starting point?

The arithmetic isn't there yet so MOVE doesn't affect the actual balances of a given account yet.